### PR TITLE
scanner bytes has to be copied to fix concurrent buffer overwrites

### DIFF
--- a/pkg/agent/messenger/messenger.go
+++ b/pkg/agent/messenger/messenger.go
@@ -88,7 +88,7 @@ func (m *messenger) Run(ctx context.Context, name string) error {
 
 		err = m.eventBus.Publish(MessageIncomingTopic, Message{
 			Type: CommandMessageType,
-			Data: scanner.Bytes(),
+			Data: append([]byte{}, scanner.Bytes()...),
 		})
 		if err != nil {
 			return err


### PR DESCRIPTION
## Description

If two commands are coming in quickly after each other the second one can overwrite the first since they share the same buffer.

## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [ ] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
