### PR TITLE
[cli] identity rule generate cmd

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.21.4
 require (
 	emperror.dev/errors v0.8.1
 	github.com/AlecAivazis/survey/v2 v2.3.7
+	github.com/dchest/validator v0.0.0-20191217151620-8e45250f2371
 	github.com/gezacorp/metadatax v0.0.0-20231204221404-cc7f265ea4ea
 	github.com/gezacorp/metadatax/collectors/azure v0.0.0-20231204181728-79757fd60d79
 	github.com/gezacorp/metadatax/collectors/docker v0.0.0-20231204221404-cc7f265ea4ea
@@ -25,6 +26,7 @@ require (
 	github.com/spf13/cobra v1.7.0
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.16.0
+	github.com/spiffe/go-spiffe/v2 v2.1.6
 	github.com/werbenhu/eventbus v1.0.8
 	github.com/zmap/zcrypto v0.0.0-20231106212110-94c8f62efae4
 	gopkg.in/fsnotify.v1 v1.4.7

--- a/go.sum
+++ b/go.sum
@@ -94,6 +94,8 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dchest/validator v0.0.0-20191217151620-8e45250f2371 h1:BuLreR1acrosGsW+njS+RxyPgL06rYTkasZA2NAogEo=
+github.com/dchest/validator v0.0.0-20191217151620-8e45250f2371/go.mod h1:ZfpgrLR1i3mQWz5fIRfkyMIh9zLOy3MwTc7hUBVPlww=
 github.com/distribution/reference v0.5.0 h1:/FUIFXtfc/x2gpa5/VGfiGLuOIdYa1t65IKK2OFGvA0=
 github.com/distribution/reference v0.5.0/go.mod h1:BbU0aIcezP1/5jX/8MP0YiH4SdvB5Y4f/wlDRiLyi3E=
 github.com/docker/distribution v2.8.3+incompatible h1:AtKxIZ36LoNK51+Z6RpzLpddBirtxJnzDrHLEKxTAYk=
@@ -319,6 +321,8 @@ github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/spf13/viper v1.16.0 h1:rGGH0XDZhdUOryiDWjmIvUSWpbNqisK8Wk0Vyefw8hc=
 github.com/spf13/viper v1.16.0/go.mod h1:yg78JgCJcbrQOvV9YLXgkLaZqUidkY9K+Dd1FofRzQg=
+github.com/spiffe/go-spiffe/v2 v2.1.6 h1:4SdizuQieFyL9eNU+SPiCArH4kynzaKOOj0VvM8R7Xo=
+github.com/spiffe/go-spiffe/v2 v2.1.6/go.mod h1:eVDqm9xFvyqao6C+eQensb9ZPkyNEeaUbqbBpOhBnNk=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=

--- a/go.work.sum
+++ b/go.work.sum
@@ -1015,8 +1015,6 @@ github.com/skratchdot/open-golang v0.0.0-20200116055534-eef842397966 h1:JIAuq3EE
 github.com/skratchdot/open-golang v0.0.0-20200116055534-eef842397966/go.mod h1:sUM3LWHvSMaG192sy56D9F7CNvL7jUJVXoqM1QKLnog=
 github.com/spaolacci/murmur3 v1.1.0/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/cobra v1.6.0/go.mod h1:IOw/AERYS7UzyrGinqmz6HLUo219MORXGxhbaJUqzrY=
-github.com/spiffe/go-spiffe/v2 v2.1.6 h1:4SdizuQieFyL9eNU+SPiCArH4kynzaKOOj0VvM8R7Xo=
-github.com/spiffe/go-spiffe/v2 v2.1.6/go.mod h1:eVDqm9xFvyqao6C+eQensb9ZPkyNEeaUbqbBpOhBnNk=
 github.com/spiffe/spire-api-sdk v1.2.5-0.20230629125323-08049dbe95e6 h1:viHj64Ur7/br8+UzaFm8DL7CUsMPM5DY+XBvA2eJ6OE=
 github.com/spiffe/spire-api-sdk v1.2.5-0.20230629125323-08049dbe95e6/go.mod h1:4uuhFlN6KBWjACRP3xXwrOTNnvaLp1zJs8Lribtr4fI=
 github.com/spiffe/spire-plugin-sdk v1.4.4-0.20230721151831-bf67dde4721d h1:LCRQGU6vOqKLfRrG+GJQrwMwDILcAddAEIf4/1PaSVc=
@@ -1183,6 +1181,8 @@ google.golang.org/grpc v1.53.0/go.mod h1:OnIrk0ipVdj4N5d9IUoFUx72/VlD7+jUsHwZgwS
 google.golang.org/grpc v1.54.0/go.mod h1:PUSEXI6iWghWaB6lXM4knEgpJNu2qUcKfDtNci3EC2g=
 google.golang.org/grpc v1.55.0 h1:3Oj82/tFSCeUrRTg/5E/7d/W5A1tj6Ky1ABAuZuv5ag=
 google.golang.org/grpc v1.55.0/go.mod h1:iYEXKGkEBhg1PjZQvoYEVPTDkHo1/bjTnfwTeGONTY8=
+google.golang.org/grpc/examples v0.0.0-20230224211313-3775f633ce20 h1:MLBCGN1O7GzIx+cBiwfYPwtmZ41U3Mn/cotLJciaArI=
+google.golang.org/grpc/examples v0.0.0-20230224211313-3775f633ce20/go.mod h1:Nr5H8+MlGWr5+xX/STzdoEqJrO+YteqFbMyCsrb6mH0=
 google.golang.org/protobuf v1.27.1/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 google.golang.org/protobuf v1.29.1/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
 google.golang.org/protobuf v1.30.0 h1:kPPoIgf3TsEvrm0PFe15JQ+570QVxYzEvvHqChK+cng=

--- a/internal/cli/cmd/agent/augment.go
+++ b/internal/cli/cmd/agent/augment.go
@@ -17,7 +17,7 @@
  * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package augment
+package agent
 
 import (
 	"fmt"
@@ -51,7 +51,7 @@ func NewAugmentCommand(c cli.CLI) *cobra.Command {
 			md, err := collector.GetMetadata(metadatax.ContextWithPID(cmd.Context(), int32(pid)))
 			if err != nil {
 				for _, e := range errors.GetErrors(err) {
-					c.Logger().Info("error during metadata collection", "error", e)
+					c.Logger().V(1).Info("error during metadata collection", "error", e)
 				}
 				err = nil
 			}

--- a/internal/cli/cmd/agent/rule.go
+++ b/internal/cli/cmd/agent/rule.go
@@ -1,0 +1,176 @@
+/*
+ * The MIT License (MIT)
+ * Copyright (c) 2023 Cisco and/or its affiliates. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial
+ * portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+ * TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package agent
+
+import (
+	"bytes"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"emperror.dev/errors"
+	"github.com/dchest/validator"
+	"github.com/spf13/cobra"
+	"github.com/spiffe/go-spiffe/v2/spiffeid"
+	"gopkg.in/yaml.v3"
+
+	"github.com/cisco-open/nasp/internal/cli"
+	"github.com/cisco-open/nasp/pkg/config/metadata/collectors"
+	"github.com/cisco-open/nasp/pkg/rules"
+	"github.com/cisco-open/nasp/pkg/tls"
+	"github.com/cisco-open/nasp/pkg/util"
+	"github.com/gezacorp/metadatax"
+)
+
+var defaultLabels = []string{
+	"process:uid",
+	"process:gid",
+	"process:binary:path",
+	"process:name",
+	"k8s:pod:name",
+	"k8s:pod:namespace",
+	"k8s:pod:serviceaccount",
+	"k8s:container:name",
+	"k8s:container:image",
+	"docker:name",
+	"docker:image:name",
+}
+
+type generateRuleCommand struct {
+	cli  cli.CLI
+	opts *generateRuleOptions
+}
+
+type generateRuleOptions struct {
+	labels           []string
+	additionalLabels []string
+	dnsNames         []string
+	ttl              time.Duration
+	allowedSPIFFEIDs []string
+	disableMTLS      bool
+}
+
+func NewGenerateRuleCommand(c cli.CLI) *cobra.Command {
+	command := &generateRuleCommand{
+		cli:  c,
+		opts: &generateRuleOptions{},
+	}
+
+	cmd := &cobra.Command{
+		Use:               "generate-identity-rule <pid> <workload ID>",
+		Aliases:           []string{"gr"},
+		Short:             "Generate identity rule for a given process",
+		SilenceErrors:     true,
+		SilenceUsage:      true,
+		DisableAutoGenTag: true,
+		Args:              cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			for _, hostname := range command.opts.dnsNames {
+				if !validator.IsValidDomain(hostname) {
+					return errors.Errorf("invalid dns name: %s", hostname)
+				}
+			}
+
+			for _, spiffeID := range command.opts.allowedSPIFFEIDs {
+				if _, err := spiffeid.FromString(spiffeID); err != nil {
+					return errors.WrapIf(err, "could not parse spiffe id")
+				}
+			}
+
+			return command.run(cmd, args)
+		},
+	}
+
+	cmd.Flags().StringSliceVar(&command.opts.labels, "label", defaultLabels, "Labels to use as selector")
+	cmd.Flags().StringSliceVar(&command.opts.additionalLabels, "add-label", []string{}, "Additional labels to use as selector")
+	cmd.Flags().StringSliceVar(&command.opts.dnsNames, "cert-dns-name", []string{}, "Set DNS name used within the issued X509 certificate")
+	cmd.Flags().DurationVar(&command.opts.ttl, "cert-ttl", tls.DefaultLeafCerticiateTTL, "TTL of the issued X509 certificate")
+	cmd.Flags().StringSliceVar(&command.opts.allowedSPIFFEIDs, "allowed-spiffe-id", []string{}, "Allowed SPIFFE ID")
+	cmd.Flags().BoolVar(&command.opts.disableMTLS, "disable-mtls", false, "Disable mTLS")
+
+	return cmd
+}
+
+func (c *generateRuleCommand) run(cmd *cobra.Command, args []string) error {
+	collector := collectors.GetMetadataCollector(c.cli.Configuration().Agent.MetadataCollectors, c.cli.Logger())
+
+	pid, err := strconv.Atoi(args[0])
+	if err != nil {
+		return err
+	}
+
+	md, err := collector.GetMetadata(metadatax.ContextWithPID(cmd.Context(), int32(pid)))
+	if err != nil {
+		for _, e := range errors.GetErrors(err) {
+			c.cli.Logger().V(1).Info("error during metadata collection", "error", e)
+		}
+		err = nil
+	}
+
+	rule := rules.Rule{
+		Selectors: []rules.Selectors{{}},
+		Properties: rules.Properties{
+			WorkloadID: args[1],
+			DNS:        c.opts.dnsNames,
+			TTL:        c.opts.ttl.String(),
+		},
+		Policy: rules.Policy{
+			MTLS:             util.BoolPointer(c.opts.disableMTLS),
+			AllowedSPIFFEIDs: c.opts.allowedSPIFFEIDs,
+		},
+	}
+
+	for _, label := range md.GetLabelsSlice() {
+		if !c.matchLabel(label.Name) {
+			continue
+		}
+
+		rule.Selectors[0][label.Name] = label.Value
+	}
+
+	if len(rule.Selectors[0]) == 0 {
+		return errors.New("could not find selectors")
+	}
+
+	buf := new(bytes.Buffer)
+	e := yaml.NewEncoder(buf)
+	e.SetIndent(2)
+	if err := e.Encode([]rules.Rule{rule}); err != nil {
+		return err
+	}
+
+	os.Stdout.Write(buf.Bytes())
+
+	return err
+}
+
+func (c *generateRuleCommand) matchLabel(label string) bool {
+	for _, l := range append(c.opts.labels, c.opts.additionalLabels...) {
+		if strings.HasSuffix(l, "*") && strings.HasPrefix(label, l[:len(l)-1]) {
+			return true
+		}
+		if l == label {
+			return true
+		}
+	}
+
+	return false
+}


### PR DESCRIPTION
## Description

Adds a CLI command for identity rule generation.

## Example

```sh
# nasp agent generate-identity-rule 5346 accounting/backend --allowed-spiffe-id spiffe://acme.corp/accounting
- selectors:
    - process:binary:path: /usr/sbin/nginx
      process:gid: "1000"
      process:name: nginx
      process:uid: "501"
  properties:
    workloadID: accounting/backend
    ttl: 24h0m0s
  policy:
    mtls: false
    allowedSPIFFEIDs:
      - spiffe://acme.corp/accounting
 ```

## Type of Change

- [ ] Bug Fix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)
