### PR TITLE
install: add signed-by to deb repo

### DIFF
--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -46,7 +46,7 @@ add_nasp_repo_and_key() {
     if [ -x "$(command -v apt)" ]; then
         # Debian/Ubuntu
         sudo apt install -y wget gnupg linux-headers-$(uname -r) dkms
-        sudo sh -c "echo 'deb $NASP_REPO_URL/packages/deb stable main' > /etc/apt/sources.list.d/nasp.list"
+        sudo sh -c "echo 'deb [signed-by=/etc/apt/trusted.gpg.d/nasp.gpg] $NASP_REPO_URL/packages/deb stable main' > /etc/apt/sources.list.d/nasp.list"
         sudo wget -O /tmp/nasp.asc "$NASP_REPO_URL/packages/nasp.asc"
         cat /tmp/nasp.asc | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/nasp.gpg >/dev/null
         sudo apt update


### PR DESCRIPTION
## Description

According to https://www.linuxuprising.com/2021/01/apt-key-is-deprecated-how-to-add.html it is still better to use signed-by in a debian repo.

## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [x] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
